### PR TITLE
Fixed typo in requirements.txt: changed PySceneDetect to scenedetect

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ datasets==2.14.0
 opencv-python==4.10.0.84
 moviepy==1.0.3
 librosa==0.10.2
-PySceneDetect==0.6.4
+scenedetect==0.6.4
 pydub==0.25.1
 
 # Natural Language Processing


### PR DESCRIPTION
I tried installing requirement.txt and only thing that gave me error was this "PySceneDetect" pip couldn't find the package so i checked and the correct package name is "scenedetect" after changing that i tried installing the packages and it installed without any problem.
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/8b52a8b0-95e6-4e73-9ffe-cc48ba1d6516" />
